### PR TITLE
Add 4.12 roks as supported version for VPC block

### DIFF
--- a/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/metadata.json
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/metadata.json
@@ -43,7 +43,7 @@
     },
     {
       "name": "supported-ocp-versions",
-      "value": "4.9,4.10,4.11"
+      "value": "4.9,4.10,4.11,4.12"
     }
     ]
   }


### PR DESCRIPTION
Tested in 4.12 cluster -> https://github.ibm.com/alchemy-containers/armada-storage/issues/4121