### PR TITLE
Update the VDO docker image for vSphere CSI Driver Template

### DIFF
--- a/config-templates/vmware/vsphere-csi-driver/2.7.0/deployment.yaml
+++ b/config-templates/vmware/vsphere-csi-driver/2.7.0/deployment.yaml
@@ -783,7 +783,7 @@ items:
                 configMapKeyRef:
                   key: auto-upgrade
                   name: compat-matrix-config
-            image: projects.registry.vmware.com/vsphere_kubernetes_driver_operator/vdo:0.5.0
+            image: projects.registry.vmware.com/vsphere_kubernetes_driver_operator/vdo:0.6.0
             imagePullPolicy: IfNotPresent
             livenessProbe:
               httpGet:


### PR DESCRIPTION
Update the vdo docker image with fix for certificate validation for webhook.