### PR TITLE
Ridge CSI driver: Add volume catalog item ID parameter

### DIFF
--- a/config-templates/ridge/ridge-csi-driver/1.0.0/storage-class-parameters.json
+++ b/config-templates/ridge/ridge-csi-driver/1.0.0/storage-class-parameters.json
@@ -13,6 +13,19 @@
 		"category": "config"
 	},
 	{
+		"description": "The ID of the volume catalog item.",
+		"displayname": "Volume catalog item ID",
+		"name": "volume-catalog-item-id",
+		"templateKeyName": [
+			"volume-catalog-item-id"
+		],
+		"required": "true",
+		"regex": "^[a-z]([-a-z0-9]*[a-z0-9])?$",
+		"min-length": 1,
+		"max-length": 64,
+		"category": "config"
+	},
+	{
 		"description": "Specify 'true' or 'false' to enable or disable volume expansion.",
 		"displayname": "Allow volume expansion",
 		"name": "allowVolumeExpansion",

--- a/config-templates/ridge/ridge-csi-driver/1.0.0/storage-class-template.yaml
+++ b/config-templates/ridge/ridge-csi-driver/1.0.0/storage-class-template.yaml
@@ -10,6 +10,8 @@ metadata:
     cloud.ridge.co/managed: "true"
   annotations:
     storageclass.kubernetes.io/is-default-class: "{{ is-default-class }}"
+parameters:
+  cloud.ridge.co/volume-catalog-item-id: {{ volume-catalog-item-id }}
 provisioner: driver.csi.ridge.com
 allowVolumeExpansion: {{ allowVolumeExpansion }}
 volumeBindingMode: WaitForFirstConsumer


### PR DESCRIPTION
Ridge is going to support multiple storage classes in Satellite, and we need a way to distinguish between them in the backend.