### PR TITLE
Add PSA labels in the namespace created by Template

### DIFF
--- a/config-templates/vmware/vsphere-csi-driver/2.7.0/deployment.yaml
+++ b/config-templates/vmware/vsphere-csi-driver/2.7.0/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: kube-system
   annotations:
     version: 2.7.0
-    revision: 1
+    revision: 2
 items:
   - apiVersion: v1
     kind: Namespace
@@ -14,6 +14,8 @@ items:
       labels:
         app.kubernetes.io/name: vsphere-csi-driver
         app.kubernetes.io/version: 2.7.0
+        pod-security.kubernetes.io/enforce: baseline
+        pod-security.kubernetes.io/enforce-version: latest
       name: vmware-system-csi
   - apiVersion: v1
     kind: Namespace
@@ -21,6 +23,8 @@ items:
       labels:
         control-plane: controller-manager
         vdo.vmware.com/managed-by: vdo
+        pod-security.kubernetes.io/enforce: baseline
+        pod-security.kubernetes.io/enforce-version: latest
       name: vmware-system-vdo
   - apiVersion: v1
     kind: ServiceAccount

--- a/config-templates/vmware/vsphere-csi-driver/2.7.0/metadata.json
+++ b/config-templates/vmware/vsphere-csi-driver/2.7.0/metadata.json
@@ -1,6 +1,6 @@
 {
     "name": "2.7.0",
-    "revision": "1",
+    "revision": "2",
     "enabled": "true",
     "status": "supported",
     "description": "VMware volume persistant storage",


### PR DESCRIPTION
Added the PSA labels in the template as the latest OC 4.12 has the PSA by default created to restricted mode.
