### PR TITLE
New VPC-Block template version with VA fixes

### DIFF
--- a/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/deployment.yaml
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
     version: 5.0
-    revision: 14
+    revision: 15
 items:
   - kind: ClusterRole
     apiVersion: rbac.authorization.k8s.io/v1
@@ -343,7 +343,7 @@ items:
             - operator: Exists
           initContainers:
             - name: vpc-node-label-updater
-              image: icr.io/obs/storage/vpc-node-label-updater:v4.2.14
+              image: icr.io/obs/storage/vpc-node-label-updater:v4.2.15
               imagePullPolicy: Always
               securityContext:
                 privileged: false
@@ -404,7 +404,7 @@ items:
                 runAsNonRoot: false
                 runAsUser: 0
                 privileged: true
-              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.21
+              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.23
               imagePullPolicy: Always
               args:
                 - "--v=5"
@@ -656,7 +656,7 @@ items:
                   mountPath: /csi
             - name: iks-vpc-block-driver
               imagePullPolicy: Always
-              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.21
+              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.23
               securityContext:
                 privileged: false
                 allowPrivilegeEscalation: false

--- a/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/metadata.json
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "5.0",
-  "revision": "14",
+  "revision": "15",
   "enabled": "true",
   "status": "supported",
   "description": "[Beta] - IBM VPC Block Storage CSI driver version 5.0",

--- a/config-templates/ibm/ibm-vpc-block-csi-driver/changelog.json
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/changelog.json
@@ -3,20 +3,20 @@
         "5.0": {
             "status": "supported",
             "latest-revision": {
-                "revision": "14",
-                "release-date": "30 October 2023",
-                "cves": "CVE-2023-4911,CVE-2023-4527,CVE-2023-4806,CVE-2023-4813,CVE-2023-39325,CVE-2023-44487",
-                "ubi": "8.8-1072.1697626218",
-                "golang": "1.20.10",
+                "revision": "15",
+                "release-date": "27 November 2023",
+                "cves": "CVE-2007-4559,CVE-2023-4641,CVE-2023-22745",
+                "ubi": "8.9-1029",
+                "golang": "1.20.11",
                 "new-features": [],
                 "fixes": []
             },
             "previous-revision": {
-                "revision": "13",
-                "release-date": "19 September 2023",
-                "cves": "CVE-2023-34969,CVE-2023-28321,CVE-2023-2602,CVE-2023-2603,CVE-2023-28484,CVE-2023-29469,CVE-2023-27536,CVE-2023-3899,CVE-2023-32681",
-                "golang": "1.19.12",
-                "ubi": "8.8-1037",
+                "revision": "14",
+                "release-date": "30 October 2023",
+                "cves": "CVE-2023-4911,CVE-2023-4527,CVE-2023-4806,CVE-2023-4813,CVE-2023-39325,CVE-2023-44487",
+                "golang": "1.20.10",
+                "ubi": "8.8-1072.1697626218",
                 "new-features": [],
                 "fixes": []
              }


### PR DESCRIPTION
```
❯ ibmcloud cr va icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.23
Checking security issues for 'icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.23'...

Image 'icr.io/ibm/ibm-vpc-block-csi-driver:v5.0.23' was last scanned on Mon Nov 20 11:46:35 UTC 2023
The scan results show that NO ISSUES were found for the image.

OK
```

```
❯ ibmcloud cr va icr.io/obs/storage/vpc-node-label-updater:v4.2.15
Checking security issues for 'icr.io/obs/storage/vpc-node-label-updater:v4.2.15'...

Image 'icr.io/obs/storage/vpc-node-label-updater:v4.2.15' was last scanned on Mon Nov 20 11:46:35 UTC 2023
The scan results show that NO ISSUES were found for the image.

OK
```