### PR TITLE
5.1 VPC Block Template Jan 24

### DIFF
--- a/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/metadata.json
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/5.0/metadata.json
@@ -2,7 +2,7 @@
   "name": "5.0",
   "revision": "15",
   "enabled": "true",
-  "status": "supported",
+  "status": "deprecated",
   "description": "[Beta] - IBM VPC Block Storage CSI driver version 5.0",
   "tags": [
     {

--- a/config-templates/ibm/ibm-vpc-block-csi-driver/5.1/deployment.yaml
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/5.1/deployment.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: kube-system
   annotations:
     version: 5.1
-    revision: 1
+    revision: 2
 items:
   - kind: ClusterRole
     apiVersion: rbac.authorization.k8s.io/v1
@@ -332,7 +332,7 @@ items:
             - operator: Exists
           initContainers:
             - name: vpc-node-label-updater
-              image: icr.io/obs/storage/vpc-node-label-updater:v4.2.15
+              image: icr.io/obs/storage/vpc-node-label-updater:v4.2.16
               imagePullPolicy: Always
               securityContext:
                 privileged: false
@@ -393,7 +393,7 @@ items:
                 runAsNonRoot: false
                 runAsUser: 0
                 privileged: true
-              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.1.18
+              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.1.19
               imagePullPolicy: Always
               args:
                 - "--v=5"
@@ -639,7 +639,7 @@ items:
                   mountPath: /csi
             - name: iks-vpc-block-driver
               imagePullPolicy: Always
-              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.1.18
+              image: icr.io/ibm/ibm-vpc-block-csi-driver:v5.1.19
               securityContext:
                 privileged: false
                 allowPrivilegeEscalation: false

--- a/config-templates/ibm/ibm-vpc-block-csi-driver/5.1/metadata.json
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/5.1/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "5.1",
-  "revision": "1",
+  "revision": "2",
   "enabled": "true",
   "status": "supported",
   "description": "[Beta] - IBM VPC Block Storage CSI driver version 5.1",

--- a/config-templates/ibm/ibm-vpc-block-csi-driver/changelog.json
+++ b/config-templates/ibm/ibm-vpc-block-csi-driver/changelog.json
@@ -3,28 +3,37 @@
         "5.1":{
             "status": "supported",
             "latest-revision": {
+                "revision": "2",
+                "release-date": "25 January 2024",
+                "cves": "CVE-2023-3446, CVE-2023-3817, CVE-2023-5678",
+                "golang": "1.20.11",
+                "ubi": "8.9-1029",
+                "new-features": [],
+                "fixes": []
+            },
+            "previous-revision": {
                 "revision": "1",
                 "release-date": "27 November 2023",
                 "cves": "",
                 "golang": "1.20.10",
                 "ubi": "8.9-1029",
                 "new-features": [
-                   "Initial release",
-                   "Updated Kubernetes dependency to 1.26",
-                   "Volumesnapshotclass supported by vpc block csi driver is made as default snapshotclass",
-                   "Priorityclass added in deployment for controller and node pods",
-                   "Removed preStop hook for csi-driver-registrar"
-                ],
-                "fixes": [
-                   "Fix for snapshot size to reflect actual source volume size",
-                   "Retry fetching IAM token, if token exchange url is unreachable"
-                ]
-            },
+                    "Initial release",
+                    "Updated Kubernetes dependency to 1.26",
+                    "Volumesnapshotclass supported by vpc block csi driver is made as default snapshotclass",
+                    "Priorityclass added in deployment for controller and node pods",
+                    "Removed preStop hook for csi-driver-registrar"
+                 ],
+                 "fixes": [
+                    "Fix for snapshot size to reflect actual source volume size",
+                    "Retry fetching IAM token, if token exchange url is unreachable"
+                 ]
+             }
         }
     },
     {
         "5.0": {
-            "status": "supported",
+            "status": "deprecated",
             "latest-revision": {
                 "revision": "15",
                 "release-date": "27 November 2023",

--- a/config-templates/template_list.json
+++ b/config-templates/template_list.json
@@ -123,7 +123,7 @@
     "name": "ibm-vpc-block-csi-driver",
     "displayname": "[Beta] IBM VPC Block CSI driver",
     "Description": "[Beta] IBM VPC Block CSI driver, Provides block storage on VPC.",
-    "default-version": "5.0",
+    "default-version": "5.1",
     "enabled": "true",
     "provider": "ibm"
   },


### PR DESCRIPTION
The new version of block driver i.e `v5.1.19` which fix CVEs

```
CVE-2023-3446      Active          openssl-libs and openssl-libs   Upgrade 2 packages. Re-run command with --extended to view.
CVE-2023-3817      Active          openssl-libs and openssl-libs   Upgrade 2 packages. Re-run command with --extended to view.
CVE-2023-5678      Active          openssl-libs and openssl-libs   Upgrade 2 packages. Re-run command with --extended to view.
```